### PR TITLE
public-i18n-core restored

### DIFF
--- a/mls.json
+++ b/mls.json
@@ -307,6 +307,11 @@
             "eventFilter": {"label":["HR: i18n-tracking","HR: i18n-comment"]}
         }
     },
+    "public-i18n-core@w3.org": {
+        "w3c/i18n-activity": {
+            "events": ["issues.opened",  "issues.closed", "issue_comment.created"]
+        }
+    },
     "public-digipub-ig@w3.org": {
         "w3c/i18n-discuss": {
             "events": ["issues.labeled", "issues.closed"],


### PR DESCRIPTION
rule had been removed while converting many project cards to issues, to avoid large unnecessary notifications to the list