### PR TITLE
i18n: webauth -> webauthn

### DIFF
--- a/mls.json
+++ b/mls.json
@@ -234,7 +234,7 @@
    	"digest:daily": [ 
             { "repos": ["w3c/typography", "w3c/predefined-counter-styles", "w3c/bp-i18n-specdev", "w3c/unicode-xml", "w3c/i18n-discuss", "w3c/i18n-drafts", "w3c/i18n-checker", "w3c/charmod-norm", "w3c/string-search", "w3c/ltli", "w3c/klreq", "w3c/ilreq", "w3c/elreq", "w3c/alreq", "w3c/unicode-xml", "w3c/clreq", "w3c/jlreq", "w3c/tlreq", "w3c/its2req", "w3c/mlw-metadata-us-impl", "w3c/mlreq", "w3c/hlreq", "w3c/string-meta"],
             "topic": "I18n repos" },
-            { "repos": ["w3c/html", "w3c/web-annotation", "w3c/csswg-drafts", "w3c/activitystreams", "w3c/webmention", "w3c/micropub", "w3c/activitypub", "w3c/ldn", "w3c/sdw", "w3c/dpub-pagination", "w3c/svgwg", "w3c/ttml2", "w3c/webvtt", "w3c/uievents", "w3c/uievents-key", "w3c/uievents-code", "w3c/browser-payment-api", "w3c/websub", "w3c/remote-playback", "w3c/data-shapes", "w3c/microdata", "w3c/push-api", "w3c/wcag21", "w3c/webauth", "w3c/IntersectionObserver", "whatwg/html", "whatwg/url"],
+            { "repos": ["w3c/html", "w3c/web-annotation", "w3c/csswg-drafts", "w3c/activitystreams", "w3c/webmention", "w3c/micropub", "w3c/activitypub", "w3c/ldn", "w3c/sdw", "w3c/dpub-pagination", "w3c/svgwg", "w3c/ttml2", "w3c/webvtt", "w3c/uievents", "w3c/uievents-key", "w3c/uievents-code", "w3c/browser-payment-api", "w3c/websub", "w3c/remote-playback", "w3c/data-shapes", "w3c/microdata", "w3c/push-api", "w3c/wcag21", "w3c/webauthn", "w3c/IntersectionObserver", "whatwg/html", "whatwg/url"],
             "eventFilter": {"label": ["i18n","i18n-comment","i18n-tracking","HR:i18n-comment","HR:i18n-tracking","i18n-review"]},
             "topic": "Review comments" }
             ]
@@ -243,7 +243,7 @@
    	"digest:sunday": [ 
             { "repos": ["w3c/i18n-activity", "w3c/typography", "w3c/predefined-counter-styles", "w3c/bp-i18n-specdev", "w3c/unicode-xml", "w3c/i18n-discuss", "w3c/i18n-drafts", "w3c/i18n-checker", "w3c/charmod-norm", "w3c/string-search", "w3c/ltli", "w3c/klreq", "w3c/ilreq", "w3c/elreq", "w3c/alreq", "w3c/unicode-xml", "w3c/clreq", "w3c/jlreq", "w3c/tlreq", "w3c/its2req", "w3c/mlw-metadata-us-impl", "w3c/mlreq", "w3c/hlreq", "w3c/string-meta"],
             "topic": "I18n repos" },
-            { "repos": ["w3c/html", "w3c/web-annotation", "w3c/csswg-drafts", "w3c/activitystreams", "w3c/webmention", "w3c/micropub", "w3c/activitypub", "w3c/ldn", "w3c/sdw", "w3c/dpub-pagination", "w3c/svgwg", "w3c/ttml2", "w3c/webvtt", "w3c/uievents", "w3c/uievents-key", "w3c/uievents-code", "w3c/browser-payment-api", "w3c/websub", "w3c/remote-playback", "w3c/data-shapes", "w3c/microdata", "w3c/imsc", "w3c/push-api", "w3c/wcag21", "w3c/webauth", "w3c/IntersectionObserver", "whatwg/html", "whatwg/url"],
+            { "repos": ["w3c/html", "w3c/web-annotation", "w3c/csswg-drafts", "w3c/activitystreams", "w3c/webmention", "w3c/micropub", "w3c/activitypub", "w3c/ldn", "w3c/sdw", "w3c/dpub-pagination", "w3c/svgwg", "w3c/ttml2", "w3c/webvtt", "w3c/uievents", "w3c/uievents-key", "w3c/uievents-code", "w3c/browser-payment-api", "w3c/websub", "w3c/remote-playback", "w3c/data-shapes", "w3c/microdata", "w3c/imsc", "w3c/push-api", "w3c/wcag21", "w3c/webauthn", "w3c/IntersectionObserver", "whatwg/html", "whatwg/url"],
             "eventFilter": {"label": ["i18n","i18n-comment","i18n-tracking","HR:i18n-comment","HR:i18n-tracking","i18n-review"]},
             "topic": "Review comments" }
             ]
@@ -256,7 +256,7 @@
    	"digest:tuesday": [ 
             { "repos": ["w3c/typography", "w3c/predefined-counter-styles", "w3c/bp-i18n-specdev", "w3c/unicode-xml", "w3c/i18n-discuss", "w3c/i18n-drafts", "w3c/i18n-checker", "w3c/charmod-norm", "w3c/string-search", "w3c/ltli", "w3c/klreq", "w3c/ilreq", "w3c/elreq", "w3c/alreq", "w3c/unicode-xml", "w3c/clreq", "w3c/jlreq", "w3c/tlreq", "w3c/its2req", "w3c/mlw-metadata-us-impl", "w3c/mlreq", "w3c/hlreq", "w3c/string-meta"],
             "topic": "I18n repos" },
-            { "repos": ["w3c/html", "w3c/web-annotation", "w3c/csswg-drafts", "w3c/activitystreams", "w3c/webmention", "w3c/micropub", "w3c/activitypub", "w3c/ldn", "w3c/sdw", "w3c/dpub-pagination", "w3c/svgwg", "w3c/ttml2", "w3c/webvtt", "w3c/uievents", "w3c/uievents-key", "w3c/uievents-code", "w3c/browser-payment-api", "w3c/websub", "w3c/remote-playback", "w3c/data-shapes", "w3c/microdata", "w3c/imsc", "w3c/push-api", "w3c/wcag21", "w3c/webauth", "w3c/IntersectionObserver", "whatwg/html", "whatwg/url"],
+            { "repos": ["w3c/html", "w3c/web-annotation", "w3c/csswg-drafts", "w3c/activitystreams", "w3c/webmention", "w3c/micropub", "w3c/activitypub", "w3c/ldn", "w3c/sdw", "w3c/dpub-pagination", "w3c/svgwg", "w3c/ttml2", "w3c/webvtt", "w3c/uievents", "w3c/uievents-key", "w3c/uievents-code", "w3c/browser-payment-api", "w3c/websub", "w3c/remote-playback", "w3c/data-shapes", "w3c/microdata", "w3c/imsc", "w3c/push-api", "w3c/wcag21", "w3c/webauthn", "w3c/IntersectionObserver", "whatwg/html", "whatwg/url"],
             "eventFilter": {"label": ["i18n","i18n-comment","i18n-tracking","HR:i18n-comment","HR:i18n-tracking","i18n-review"]},
             "topic": "Review comments" }
             ]


### PR DESCRIPTION
Fixes a bug that has prevented delivery of several digests since 27 Sep.