### PR TITLE
Stop Media & Entertainment digest experiment

### DIFF
--- a/mls.json
+++ b/mls.json
@@ -797,39 +797,17 @@
             }
         }
     },
-    "team-webandtv-chairs@w3.org": {
+    "team-entertainment@w3.org": {
         "digest:wednesday": [
             {
-                "repos": ["wicg/media-capabilities", "wicg/mediasession", "wicg/picture-in-picture", "wicg/shape-detection-api", "wicg/encrypted-media-encryption-scheme", "wicg/hdcp-detection"],
-                "topic": "Media related proposals in WICG"
-            },
-            {
-                "repos": ["w3c/ttml1", "w3c/ttml2", "w3c/webvtt", "w3c/ttml-webvtt-mapping", "w3c/tt-profile-registry", "w3c/imsc", "w3c/imsc-vnext-reqs", "w3c/png-hdr-pq"],
-                "topic": "Timed Text WG"
-            },
-            {
-                "repos": ["w3c/presentation-api", "w3c/remote-playback", "webscreens/openscreenprotocol"],
-                "topic": "Second Screen WG/CG"
-            },
-            {
-                "repos": ["WebAudio/web-audio-api", "WebAudio/web-midi-api"],
-                "topic": "Web Audio WG"
-            },
-            {
-                "repos": ["w3c/webmediaapi", "w3c/webmediaguidelines", "w3c/webmediaporting"],
-                "topic": "Web Media API CG"
-            },
-            {
-                "repos": ["immersive-web/webxr", "immersive-web/proposals"],
-                "topic": "Immersive Web CG"
-            },
-            {
-                "repos": ["w3c/ColorWeb-CG"],
-                "topic": "Color on the Web CG"
-            },
-            {
-                "repos": ["webtiming/timingobject"],
-                "topic": "Multi-Device Timing CG"
+                "repos": [
+                    "wicg/media-capabilities", "wicg/mediasession", "wicg/media-source", "wicg/picture-in-picture", "wicg/shape-detection-api", "wicg/encrypted-media-encryption-scheme", "wicg/hdcp-detection", "wicg/spatial-navigation",
+                    "w3c/webmediaapi", "w3c/webmediaguidelines", "w3c/webmediaporting",
+                    "w3c/ColorWeb-CG",
+                    "immersive-web/webxr", "immersive-web/proposals",
+                    "webtiming/timingobject"
+                ],
+                "topic": "Media related proposals in Community Groups"
             }
         ]
     }


### PR DESCRIPTION
Stop sending multiple digest emails to the Media & Entertainment IG chairs mailing-list. Rather send one digest email for media related CG activity to the team-entertainment mailing-list.