### PR TITLE
Temporarily stop email notifications

### DIFF
--- a/mls.json
+++ b/mls.json
@@ -644,10 +644,7 @@
             }
         },
         "w3c/smufl": {
-            "events": ["issues.opened",  "issues.closed", "issue_comment.created", "pull_request.opened"],
-            "branches": {
-                "gh-pages": ["push"]
-            }
+            "events": ["issues.opened",  "issues.closed", "issue_comment.created"]
         }
     },
     "webrtc-chairs@w3.org": {


### PR DESCRIPTION
(Apologies for this being a fresh pull request: I am still inexperienced with the git workflow. Sorry for any time wasted.)

I am one of the co-chairs of the W3C Music Notation Community Group. I need to make some changes to the w3c/smufl repository but don't want to spam the public-music-notation-contrib list with emails regarding the changes. This pull request temporarily stops notifications for those actions.

I will submit a further pull request when I'm ready to re-enable these notifications.