### PR TITLE
Reflect transitions

### DIFF
--- a/mls.json
+++ b/mls.json
@@ -855,5 +855,21 @@
         "topic": "WAI Repos Activity"
       }
     ]
-  }
+  },
+  "chairs@w3.org": {
+    "digest:daily": [
+         {
+          "repos": ["w3c/transitions"],
+          "events": ["issues.opened",  "issues.closed", "issue_comment.created"],
+          "eventFilter": { "label": ["Awaiting Director"] }
+        }
+    ]
+ },
+ "public-transition-announce@w3.org": {
+    "w3c/sdw": {
+        "repos": ["w3c/transitions"],
+        "events": ["issues.opened",  "issues.closed", "issue_comment.created"],
+        "eventFilter": { "label": ["Awaiting Director", "Entering FPWD", "Entering FPNote", "Entering CR", "Updating CR", "Entering PR"]  }
+    }
+ }
 }


### PR DESCRIPTION
This integrate w3c/transitions in the transition requirements workflow.

As discussed with Ralph, we can try this config and tweak it as needed, based on chairs feedback.

