### PR TITLE
Don't react on comments and issue closures

### DIFF
--- a/mls.json
+++ b/mls.json
@@ -864,16 +864,14 @@
     ]
   },
   "chairs@w3.org": {
-    "digest:daily": [
-         {
-          "repos": ["w3c/transitions"],
-          "eventFilter": { "label": ["Entering FPWD", "Entering FPNote", "Entering CR", "Updating CR", "Entering PR"]  }
-        }
-    ]
+    "w3c/transitions": {
+        "events": ["issues.opened"],
+        "eventFilter": { "label": ["Entering FPWD", "Entering FPNote", "Entering CR", "Updating CR", "Entering PR"]  }
+    }
   },
   "public-transition-announce@w3.org": {
     "w3c/transitions": {
-        "events": ["issues.opened", "issue_comment.created", "issues.labeled"],
+        "events": ["issues.opened"],
         "eventFilter": { "label": ["Entering FPWD", "Entering FPNote", "Entering CR", "Updating CR", "Entering PR"]  }
     }
   },


### PR DESCRIPTION
@dontcallmedom , I don't think you can filter out comments and closures for a daily digest (it doesn't accept the property "events"). So, I changed it to send the email right away if an issue is opened.
