### PR TITLE
Reduce Music Notation Community Group emails

### DIFF
--- a/mls.json
+++ b/mls.json
@@ -670,14 +670,20 @@
      }
  },
     "public-music-notation-contrib@w3.org": {
-        "w3c/musicxml": {
-            "events": ["issues.opened",  "issues.closed", "issue_comment.created", "pull_request.opened"],
+        "w3c/mnx": {
+            "branches": {
+                "master": ["push"]
+            }
+        },
+       "w3c/musicxml": {
             "branches": {
                 "gh-pages": ["push"]
             }
         },
         "w3c/smufl": {
-            "events": ["issues.opened",  "issues.closed", "issue_comment.created"]
+            "branches": {
+                "gh-pages": ["push"]
+            }
         }
     },
     "webrtc-chairs@w3.org": {


### PR DESCRIPTION
I am a co-chair of the Music Notation Community Group. We would like to reduce the notifications from our repositories to the mailing list, relying primarily on people subscribing to GitHub instead. One repository was added so we have consistency among all 3 projects.