### PR TITLE
Add WHATWG HTML & DOM to the public-html weekly digest.

### DIFF
--- a/mls.json
+++ b/mls.json
@@ -898,7 +898,7 @@
     },
     "public-html@w3.org": {
         "digest:monday": {
-            "repos": ["w3c/html-aam", "w3c/html-aria", "w3c/html-extensions", "w3c/htmlwg", "w3c/webcomponents"],
+            "repos": ["w3c/html-aam", "w3c/html-aria", "w3c/html-extensions", "w3c/htmlwg", "w3c/webcomponents", "whatwg/html"],
             "topic": "HTML specs"
         }
     },

--- a/mls.json
+++ b/mls.json
@@ -898,7 +898,7 @@
     },
     "public-html@w3.org": {
         "digest:monday": {
-            "repos": ["w3c/html-aam", "w3c/html-aria", "w3c/html-extensions", "w3c/htmlwg", "w3c/webcomponents", "whatwg/html"],
+            "repos": ["w3c/html-aam", "w3c/html-aria", "w3c/html-extensions", "w3c/htmlwg", "w3c/webcomponents", "whatwg/html", "whatwg/dom"],
             "topic": "HTML specs"
         }
     },


### PR DESCRIPTION
Since they're the two WHATWG specs the HTML WG moves along the REC track under the MoU.