### PR TITLE
Add patwg-charter under patcg to notification list

### DIFF
--- a/mls.json
+++ b/mls.json
@@ -107,6 +107,15 @@
 			"pull_request.opened",
 			"pull_request.closed"
 		]
+	},
+	"patcg/patwg-charter": {
+		"events": [
+			"issues.opened",
+			"issues.closed",
+			"issue_comment.created",
+			"pull_request.opened",
+			"pull_request.closed"
+		]
     }
   },
     "public-webrtc@w3.org": {


### PR DESCRIPTION
This PR adds the new PATCG repo `patwg-charter` tracking the work on the Private Ad Technology Working Group charter to the set of repos the PATCG mailing list should receive notifications on. 