### PR TITLE
remove old demjson python package

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,8 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: |
-             pip install demjson jsonschema
+             pip install jsonschema
              python -mjson.tool mls.json > /dev/null
-             jsonlint mls.json
              jsonschema -i mls.json config.schema
   


### PR DESCRIPTION
For #248 GHAction error, demjson package installation seems failed.
https://github.com/w3c/github-notify-ml-config/actions/runs/3742513254/jobs/6353548440
Since
- this package is quite old and not maintained recently, and seems relying on 2to3 helper (setuptools removed support from v58)
- json format is validated by both jsonlint (from demjson) and `python -mjson.tool`, both of which are validation in strict mode, so dup as functionality
I'd propose to remove this tool and validation line, with keeping validation by json package, as this PR.

/cc @anssiko