### PR TITLE
added new repositories for public-device-apis

### DIFF
--- a/mls.json
+++ b/mls.json
@@ -642,9 +642,12 @@
         "w3c/battery",
         "w3c/screen-wake-lock",
         "w3c/system-wake-lock",
+        "w3c/device-posture",
         "w3c/html-media-capture",
         "w3c/vibration",
-        "w3c/dap-charter"
+        "w3c/das-charter",
+        "w3c/compute-pressure",
+        "w3c/contact-picker"
       ],
       "topic": "Devices and Sensors WG specifications"
     }


### PR DESCRIPTION
updating mls.json for public-device-apis, to sync with a list for public-device-apis-log
added two new, and fixed missing and changed.

@anssiko  do we want to update `tr.published` events with list of specs in /TR/? (only `wake-lock` is listed currently)