### PR TITLE
Update repos for Credentials CG.

### DIFF
--- a/mls.json
+++ b/mls.json
@@ -2213,10 +2213,10 @@
           "w3c/vc-test-suite",
           "w3c/vc-imp-guide",
           "w3c/vc-use-cases",
-          "w3c/vc-wg-charter",
           "w3c/vc-data-integrity",
           "w3c/vc-jws-2020",
-          "w3c/vc-jwt"
+          "w3c/vc-jwt",
+          "w3c/vc-status-list-2021"
         ],
         "topic": "Weekly update on Verifiable Credentials WG activity"
       }


### PR DESCRIPTION
This PR removes the vc-wg-charter and adds the vc-status-list-2021 repo for the summary to the Credentials CG.