### PR TITLE
Update webappswg repos

### DIFF
--- a/mls.json
+++ b/mls.json
@@ -1835,7 +1835,7 @@
     "digest:monday": [
       {
         "repos": [
-	  "w3c/html-aria/",
+	  "w3c/html-aria",
           "w3c/badging",
           "w3c/FileAPI",
           "w3c/gamepad",

--- a/mls.json
+++ b/mls.json
@@ -1835,6 +1835,7 @@
     "digest:monday": [
       {
         "repos": [
+	  "w3c/html-aria/",
           "w3c/badging",
           "w3c/FileAPI",
           "w3c/gamepad",
@@ -1845,6 +1846,7 @@
           "w3c/push-api",
           "w3c/screen-orientation",
           "w3c/uievents",
+          "w3c/web-locks",
           "w3c/web-share",
           "whatwg/dom",
           "whatwg/infra",

--- a/mls.json
+++ b/mls.json
@@ -1837,6 +1837,7 @@
         "repos": [
 	  "w3c/html-aria",
           "w3c/badging",
+          "w3c/contact-picker",
           "w3c/FileAPI",
           "w3c/gamepad",
           "w3c/image-resource",


### PR DESCRIPTION
Was missing the following for WebApps WG:
* w3c/html-aria
* w3c/contact-picker
* w3c/web-locks