### PR TITLE
Add horizontal reviews of charter from PING

### DIFF
--- a/mls.json
+++ b/mls.json
@@ -488,6 +488,14 @@
     "w3cping/privacy-request": {
       "events": ["issues.labeled"],
       "eventFilter": { "label": ["REVIEW REQUESTED"] }
+    },
+    "w3c/strategy": {
+      "events": ["issues.labeled"],
+      "eventFilter": {
+        "label": [
+          "Horizontal review requested"
+        ]
+      }
     }
   },
   "public-ortc@w3.org": {


### PR DESCRIPTION
This will alert public-privacy when a charter requests horizontal review.

cc @pes10k @npdoty @sandandsnow
