### PR TITLE
Add pm wg weekly digest

### DIFF
--- a/mls.json
+++ b/mls.json
@@ -2322,7 +2322,7 @@
             "issue.labeled",
             "pull_request.labeled"
           ]
-          "eventFilter": { "label": ["Final Review"] },
+          "eventFilter": { "label": ["Final Review"] }
         }
       ]
     }

--- a/mls.json
+++ b/mls.json
@@ -2305,26 +2305,25 @@
     }
   },		
   "public-pm-wg@w3.org": {
-    "digest:thursday": {
-      "topic:": "Weekly Publishing Maintenance WG GitHub activity",
-      "sources": [
-        {
-          "repos": ["w3c/epub-specs"],
-          "events": [
-            "issues.opened",
-            "issue_comment.created",
-            "pull_request.opened"
-          ]
-        },
-        {
-          "repos": ["w3c/epub-specs"],
-          "events": [
-            "issue.labeled",
-            "pull_request.labeled"
-          ],
-          "eventFilter": { "label": ["Final Review"] }
-        }
-      ]
-    }
+    "digest:thursday": [
+      {
+        "topic:": "New activity in the epub-specs GitHub repository",
+        "repos": ["w3c/epub-specs"],
+        "events": [
+          "issues.opened",
+          "issue_comment.created",
+          "pull_request.opened"
+        ]
+      },
+      {
+        "topic:": "New FINAL REVIEW requests in the epub-specs GitHub repository",
+        "repos": ["w3c/epub-specs"],
+        "events": [
+          "issue.labeled",
+          "pull_request.labeled"
+        ],
+        "eventFilter": { "label": ["Final Review"] }
+      }
+    ]
   }
 }

--- a/mls.json
+++ b/mls.json
@@ -2308,7 +2308,7 @@
     "digest:thursday": [
       {
         "topic:": "Activity in the epub-specs GitHub repository",
-        "repos": ["w3c/epub-specs"],
+        "repos": ["w3c/epub-specs"]
       },
       {
         "topic:": "New FINAL REVIEW requests in the epub-specs GitHub repository",

--- a/mls.json
+++ b/mls.json
@@ -2303,5 +2303,28 @@
         "gh-pages": ["push"]
       }
     }
-  }		
+  },		
+  "public-pm-wg@w3.org": {
+    "digest:friday": {
+      "topic:": "Weekly Publishing Maintenance WG GitHub activity",
+      "sources": [
+        {
+          "repos": ["w3c/epub-specs"],
+          "events": [
+            "issues.opened",
+            "issue_comment.created",
+            "pull_request.opened"
+          ]
+        },
+        {
+          "repos": ["w3c/epub-specs"],
+          "events": [
+            "issue.labeled",
+            "pull_request.labeled"
+          ]
+          "eventFilter": { "label": ["Final Review"] },
+        }
+      ]
+    }
+  }
 }

--- a/mls.json
+++ b/mls.json
@@ -2321,7 +2321,7 @@
           "events": [
             "issue.labeled",
             "pull_request.labeled"
-          ]
+          ],
           "eventFilter": { "label": ["Final Review"] }
         }
       ]

--- a/mls.json
+++ b/mls.json
@@ -2305,7 +2305,7 @@
     }
   },		
   "public-pm-wg@w3.org": {
-    "digest:friday": {
+    "digest:thursday": {
       "topic:": "Weekly Publishing Maintenance WG GitHub activity",
       "sources": [
         {

--- a/mls.json
+++ b/mls.json
@@ -2311,7 +2311,7 @@
           "w3c/epub-specs"
         ],
         "eventFilter": { "label": ["Final Review"] },
-        "topic": "New FINAL REVIEW requests in the epub-specs GitHub repository"
+        "topic": "FINAL REVIEW requests in the epub-specs GitHub repository"
       }
     ],
     "digest:friday": [
@@ -2319,6 +2319,7 @@
         "repos": [
           "w3c/epub-specs"
         ],
+        "eventFilter": { "notlabel": ["Final Review"] },
         "topic": "New activity in the epub-specs GitHub repository"
       }
     ]

--- a/mls.json
+++ b/mls.json
@@ -2307,13 +2307,19 @@
   "public-pm-wg@w3.org": {
     "digest:thursday": [
       {
-        "topic:": "Activity in the epub-specs GitHub repository",
-        "repos": ["w3c/epub-specs"]
-      },
+        "repos": [
+          "w3c/epub-specs"
+        ],
+        "eventFilter": { "label": ["Final Review"] },
+        "topic": "New FINAL REVIEW requests in the epub-specs GitHub repository"
+      }
+    ],
+    "digest:friday": [
       {
-        "topic:": "New FINAL REVIEW requests in the epub-specs GitHub repository",
-        "repos": ["w3c/epub-specs"],
-        "eventFilter": { "label": ["Final Review"] }
+        "repos": [
+          "w3c/epub-specs"
+        ],
+        "topic": "New activity in the epub-specs GitHub repository"
       }
     ]
   }

--- a/mls.json
+++ b/mls.json
@@ -2307,21 +2307,12 @@
   "public-pm-wg@w3.org": {
     "digest:thursday": [
       {
-        "topic:": "New activity in the epub-specs GitHub repository",
+        "topic:": "Activity in the epub-specs GitHub repository",
         "repos": ["w3c/epub-specs"],
-        "events": [
-          "issues.opened",
-          "issue_comment.created",
-          "pull_request.opened"
-        ]
       },
       {
         "topic:": "New FINAL REVIEW requests in the epub-specs GitHub repository",
         "repos": ["w3c/epub-specs"],
-        "events": [
-          "issue.labeled",
-          "pull_request.labeled"
-        ],
         "eventFilter": { "label": ["Final Review"] }
       }
     ]


### PR DESCRIPTION
@dontcallmedom (or to anyone else who can answer this) We're trying to enable a weekly digest for the epub specifications that will include all new activity (issues, comments, pull requests) and also select pull requests and issues that are labeled in final review.

I've used a `sources` key with two entries for the epub-specs repository to accomplish this, but please let me know if this won't accomplish what we want or if there's a better way to do it. (I'm not sure if we merged the events into one entry if the event filter would prevent new activity not labeled as final review from being captured or if it only affects .labeled activity.)

Thanks!

/cc @iherman @wareid @shiestyle 